### PR TITLE
Add a json configuration file and ability to add retry at global level

### DIFF
--- a/src/xRetry.SpecFlow/Constants.cs
+++ b/src/xRetry.SpecFlow/Constants.cs
@@ -3,5 +3,7 @@ namespace xRetry.SpecFlow
     internal static class Constants
     {
         public const string RETRY_TAG = "retry";
+        public const string RETRY_ATTRIBUTE = "xRetry.RetryFact";
+        public const string IGNORE_TAG = "ignore";
     }
 }

--- a/src/xRetry.SpecFlow/Constants.cs
+++ b/src/xRetry.SpecFlow/Constants.cs
@@ -3,7 +3,9 @@ namespace xRetry.SpecFlow
     internal static class Constants
     {
         public const string RETRY_TAG = "retry";
+        public const string RETRY_ROOT_ATTRIBUTE = "xRetry.Retry";
         public const string RETRY_ATTRIBUTE = "xRetry.RetryFact";
+        public const string RETRY_THEORY_ATTRIBUTE = "xRetry.RetryTheory";
         public const string IGNORE_TAG = "ignore";
     }
 }

--- a/src/xRetry.SpecFlow/GeneratorPlugin.cs
+++ b/src/xRetry.SpecFlow/GeneratorPlugin.cs
@@ -1,4 +1,5 @@
 using TechTalk.SpecFlow.Generator.Plugins;
+using TechTalk.SpecFlow.Generator.UnitTestConverter;
 using TechTalk.SpecFlow.Generator.UnitTestProvider;
 using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.UnitTestProvider;
@@ -6,18 +7,30 @@ using xRetry.SpecFlow;
 using xRetry.SpecFlow.Parsers;
 
 [assembly: GeneratorPlugin(typeof(GeneratorPlugin))]
+
 namespace xRetry.SpecFlow
 {
     public class GeneratorPlugin : IGeneratorPlugin
     {
-        public void Initialize(GeneratorPluginEvents generatorPluginEvents, GeneratorPluginParameters generatorPluginParameters,
+        public void Initialize(
+            GeneratorPluginEvents generatorPluginEvents,
+            GeneratorPluginParameters generatorPluginParameters,
             UnitTestProviderConfiguration unitTestProviderConfiguration)
         {
+            generatorPluginEvents.RegisterDependencies += RegisterDependencies;
             generatorPluginEvents.CustomizeDependencies += customiseDependencies;
+        }
+
+        private void RegisterDependencies(object sender, RegisterDependenciesEventArgs eventArgs)
+        {
+            eventArgs.ObjectContainer.RegisterTypeAs<RetryAttributeGenerator, ITestMethodDecorator>("AttributeGenerator.retry");
         }
 
         private void customiseDependencies(object sender, CustomizeDependenciesEventArgs eventArgs)
         {
+            var retrySettings = RetrySettings.LoadConfiguration();
+            eventArgs.ObjectContainer.RegisterInstanceAs<IRetrySettings>(retrySettings);
+            eventArgs.ObjectContainer.RegisterTypeAs<Logger, ILogger>();
             eventArgs.ObjectContainer.RegisterTypeAs<RetryTagParser, IRetryTagParser>();
             eventArgs.ObjectContainer.RegisterTypeAs<TestGeneratorProvider, IUnitTestGeneratorProvider>();
         }

--- a/src/xRetry.SpecFlow/Logger.cs
+++ b/src/xRetry.SpecFlow/Logger.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using System.Text;
+using Utf8Json;
+
+namespace xRetry.SpecFlow
+{
+    public interface ILogger
+    {
+        void Log(string msg);
+        void Log<T>(T obj);
+    }
+
+    public class Logger : ILogger
+    {
+        private readonly IRetrySettings retrySettings;
+
+        public Logger(IRetrySettings retrySettings)
+        {
+            this.retrySettings = retrySettings;
+        }
+
+        public void Log(string msg)
+        {
+            if (!retrySettings.isVerbose) return;
+
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "retrySpecflowPlugin.log");
+            using (var file = new StreamWriter(path, true))
+            {
+                file.WriteLine(msg);
+            }
+        }
+
+        public void Log<T>(T obj)
+        {
+            var msg = JsonSerializer.PrettyPrint(JsonSerializer.Serialize(obj));
+            Log(msg);
+        }
+    }
+}

--- a/src/xRetry.SpecFlow/Parsers/RetryTagParser.cs
+++ b/src/xRetry.SpecFlow/Parsers/RetryTagParser.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.RegularExpressions;
 
 namespace xRetry.SpecFlow.Parsers
@@ -6,32 +5,32 @@ namespace xRetry.SpecFlow.Parsers
     public class RetryTagParser : IRetryTagParser
     {
         // unescaped: ^retry(\(([0-9]+)(,([0-9]+))?\))?$
-        private readonly Regex regex = new Regex($"^{Constants.RETRY_TAG}(\\(([0-9]+)(,([0-9]+))?\\))?$",
+        private readonly Regex regex = new Regex(
+            $"^{Constants.RETRY_TAG}(\\(([0-9]+)(,([0-9]+))?\\))?$",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private readonly IRetrySettings retrySettings;
+
+        public RetryTagParser(IRetrySettings retrySettings)
+        {
+            this.retrySettings = retrySettings;
+        }
 
         public RetryTag Parse(string tag)
         {
-            if (tag == null)
-            {
-                throw new ArgumentNullException(nameof(tag));
-            }
+            if (tag == null) return new RetryTag(retrySettings.MaxRetry, retrySettings.DelayBetweenRetriesMs);
 
-            int? maxRetries = null;
-            int? delayBetweenRetriesMs = null;
-
-            Match match = regex.Match(tag);
-            if (match.Success)
+            int? maxRetries = retrySettings.MaxRetry;
+            int? delayBetweenRetriesMs = retrySettings.DelayBetweenRetriesMs;
+            var match = regex.Match(tag);
+            if (match.Success && match.Groups[2].Success)
             {
-                // Group 2 is max retries
-                if(match.Groups[2].Success)
+                maxRetries = int.Parse(match.Groups[2].Value);
+
+                // Group 4 is delay between retries
+                if (match.Groups[4].Success)
                 {
-                    maxRetries = int.Parse(match.Groups[2].Value);
-
-                    // Group 4 is delay between retries
-                    if (match.Groups[4].Success)
-                    {
-                        delayBetweenRetriesMs = int.Parse(match.Groups[4].Value);
-                    }
+                    delayBetweenRetriesMs = int.Parse(match.Groups[4].Value);
                 }
             }
 

--- a/src/xRetry.SpecFlow/RetryAttributeGenerator.cs
+++ b/src/xRetry.SpecFlow/RetryAttributeGenerator.cs
@@ -1,0 +1,72 @@
+﻿using System.CodeDom;
+using System.Collections;
+using System.Linq;
+using System.Text.RegularExpressions;
+using TechTalk.SpecFlow.Generator;
+using TechTalk.SpecFlow.Generator.UnitTestConverter;
+
+namespace xRetry.SpecFlow
+{
+    public class RetryAttributeGenerator : ITestMethodDecorator
+    {
+        private readonly ILogger logger;
+        private readonly IRetrySettings retrySettings;
+
+        public RetryAttributeGenerator(
+            IRetrySettings retrySettings,
+            ILogger logger)
+        {
+            this.retrySettings = retrySettings;
+            this.logger = logger;
+        }
+
+        public int Priority => PriorityValues.Normal;
+
+        public bool CanDecorateFrom(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            logger.Log("===============================================");
+            logger.Log($"{nameof(CanDecorateFrom)} : {testMethod.Name}");
+
+            if (!retrySettings.Global)
+            {
+                logger.Log($"Global is disable");
+                return false;
+            }
+            
+            var isTagMustBeAdded = !generationContext.Feature.Tags
+                .Any(tag => Regex.IsMatch(tag.Name, "@ignore", RegexOptions.Compiled | RegexOptions.IgnoreCase));
+
+            isTagMustBeAdded = isTagMustBeAdded && !testMethod.CustomAttributes
+                .OfType<CodeAttributeDeclaration>()
+                .Any(declaration => declaration.Name.StartsWith(Constants.RETRY_ATTRIBUTE));
+
+            logger.Log($"isTagMustBeAdded : {isTagMustBeAdded}");
+
+            return isTagMustBeAdded;
+        }
+
+        public void DecorateFrom(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            logger.Log($"{nameof(DecorateFrom)} : {testMethod.Name}");
+
+
+            for (var i = testMethod.CustomAttributes.Count - 1; i >= 0; i--)
+            {
+                var testMethodCustomAttribute = testMethod.CustomAttributes[i];
+                if (Regex.IsMatch(
+                    testMethodCustomAttribute.AttributeType.BaseType,
+                    "Fact(Attribute)?$",
+                    RegexOptions.Compiled | RegexOptions.IgnoreCase))
+                    testMethod.CustomAttributes.Remove(testMethodCustomAttribute);
+            }
+
+            testMethod.CustomAttributes.Add(
+                new CodeAttributeDeclaration(
+                    Constants.RETRY_ATTRIBUTE,
+                    new CodeAttributeArgument(new CodePrimitiveExpression(retrySettings.MaxRetry)),
+                    new CodeAttributeArgument(new CodePrimitiveExpression(retrySettings.DelayBetweenRetriesMs))
+                )
+            );
+        }
+    }
+}

--- a/src/xRetry.SpecFlow/RetrySettings.cs
+++ b/src/xRetry.SpecFlow/RetrySettings.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using System.Text;
+using Utf8Json;
+using Utf8Json.Resolvers;
+
+namespace xRetry.SpecFlow
+{
+    public interface IRetrySettings
+    {
+        bool isVerbose { get; set; }
+        bool Global { get; set; }
+        int MaxRetry { get; set; }
+        int DelayBetweenRetriesMs { get; set; }
+    }
+
+    public class RetrySettings : IRetrySettings
+    {
+        public bool isVerbose { get; set; }
+        public bool Global { get; set; }
+        public int MaxRetry { get; set; } = 3;
+        public int DelayBetweenRetriesMs { get; set; } = 5000;
+
+        public static RetrySettings LoadConfiguration()
+        {
+            var retrySettings = new RetrySettings();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "retrySettings.json");
+            if (!File.Exists(path))
+            {
+                var serializedBytes = JsonSerializer.Serialize(retrySettings);
+                var serializedString = JsonSerializer.PrettyPrint(serializedBytes);
+                File.WriteAllText(path, serializedString);
+                return retrySettings;
+            }
+            
+            retrySettings = JsonSerializer.Deserialize<RetrySettings>(File.ReadAllText(path));
+            var logger = new Logger(retrySettings);
+            logger.Log(retrySettings);
+
+            return retrySettings;
+        }
+    }
+}

--- a/src/xRetry.SpecFlow/TestGeneratorProvider.cs
+++ b/src/xRetry.SpecFlow/TestGeneratorProvider.cs
@@ -40,6 +40,16 @@ namespace xRetry.SpecFlow
             scenarioCategories = scenarioCategories as string[] ?? scenarioCategories.ToArray();
 
             base.SetTestMethodCategories(generationContext, testMethod, scenarioCategories);
+            
+            // Remove all retry attribute to have a clean desk 
+            var removeThisAttribute = testMethod.CustomAttributes
+                .OfType<CodeAttributeDeclaration>()
+                .FirstOrDefault(declaration => declaration.Name.StartsWith(Constants.RETRY_ROOT_ATTRIBUTE));
+                
+            if(removeThisAttribute != null)
+            {
+                testMethod.CustomAttributes.Remove(removeThisAttribute);
+            }
 
             // Do not add retries to skipped tests (even if they have the retry attribute) as retrying won't affect the outcome.
             //  This allows for the new (for SpecFlow 3.1.x) implementation that relies on Xunit.SkippableFact to still work, as it
@@ -47,16 +57,6 @@ namespace xRetry.SpecFlow
             if (IsIgnored(generationContext, scenarioCategories))
             {
                 logger.Log("test must be skipped");
-                
-                var removeThisAttribute = testMethod.CustomAttributes
-                    .OfType<CodeAttributeDeclaration>()
-                    .FirstOrDefault(declaration => declaration.Name.StartsWith(Constants.RETRY_ATTRIBUTE));
-                
-                if(removeThisAttribute != null)
-                {
-                    testMethod.CustomAttributes.Remove(removeThisAttribute);
-                }
-                
                 return;
             }
 

--- a/test/UnitTests/SpecFlow/Features/GlobalRetryScenarioOutlines.feature
+++ b/test/UnitTests/SpecFlow/Features/GlobalRetryScenarioOutlines.feature
@@ -1,0 +1,14 @@
+﻿@retry
+Feature: Global Retry Scenarios Outlines
+	In order to allow for transient failures
+	As a QA engineer
+	I want to be able to run scenario tests multiple times until they pass
+
+Scenario Outline: Retry implicit three times by default
+	When I increment the global outline retry count for test <n>
+	Then the global outline retry could for test <n> should be 3
+	Examples:
+	| n |
+	| 1 |
+	| 2 |
+

--- a/test/UnitTests/SpecFlow/Features/GlobalRetryScenarios.feature
+++ b/test/UnitTests/SpecFlow/Features/GlobalRetryScenarios.feature
@@ -1,0 +1,9 @@
+﻿@retry
+Feature: Global Retry Scenarios
+	In order to allow for transient failures
+	As a QA engineer
+	I want to be able to run scenario tests multiple times until they pass
+
+Scenario: Retry implicit three times by default
+	When I increment the global retry count
+	Then the global result should be 3

--- a/test/UnitTests/SpecFlow/Features/RetryScenarioOutlines.feature
+++ b/test/UnitTests/SpecFlow/Features/RetryScenarioOutlines.feature
@@ -3,6 +3,14 @@ Feature: Retry Scenario Outlines
 	As a QA engineer
 	I want to be able to run scenario outline tests multiple times until they pass
 
+Scenario Outline: Retry implicit three times by default
+	When I increment the default retry count for test <n>
+	Then the default retry could for test <n> should be 3
+	Examples:
+	| n |
+	| 1 |
+	| 2 |
+
 @retry
 Scenario Outline: Retry three times by default
 	When I increment the default retry count for test <n>

--- a/test/UnitTests/SpecFlow/Features/RetryScenarios.feature
+++ b/test/UnitTests/SpecFlow/Features/RetryScenarios.feature
@@ -3,6 +3,10 @@ Feature: Retry Scenarios
 	As a QA engineer
 	I want to be able to run scenario tests multiple times until they pass
 
+Scenario: Retry implicit three times by default
+	When I increment the default retry count
+	Then the default result should be 3
+
 @retry
 Scenario: Retry three times by default
 	When I increment the default retry count

--- a/test/UnitTests/SpecFlow/Parsers/RetryTagParserTests.cs
+++ b/test/UnitTests/SpecFlow/Parsers/RetryTagParserTests.cs
@@ -1,4 +1,4 @@
-using System;
+using xRetry.SpecFlow;
 using xRetry.SpecFlow.Parsers;
 using Xunit;
 
@@ -7,18 +7,27 @@ namespace UnitTests.SpecFlow.Parsers
     public class RetryTagParserTests
     {
         [Fact]
-        public void Parse_Null_ThrowsArgumentNullException() =>
-            Assert.Throws<ArgumentNullException>(() => getParser().Parse(null));
+        public void Parse_Null_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var expected = new RetryTag(3, 5000);
+
+            // Act
+            var actual = getParser().Parse(null);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
 
         [Fact]
         public void Parse_NoParams_CorrectResult()
         {
             // Arrange
-            RetryTagParser parser = getParser();
-            RetryTag expected = new RetryTag(null, null);
+            var parser = getParser();
+            var expected = new RetryTag(3, 5000);
 
             // Act
-            RetryTag actual = parser.Parse("retry");
+            var actual = parser.Parse("retry");
 
             // Assert
             Assert.Equal(expected, actual);
@@ -32,11 +41,11 @@ namespace UnitTests.SpecFlow.Parsers
         public void Parse_MaxRetries_ReturnsCorrectResult(string tag, int maxRetries)
         {
             // Arrange
-            RetryTagParser parser = getParser();
-            RetryTag expected = new RetryTag(maxRetries, null);
+            var parser = getParser();
+            var expected = new RetryTag(maxRetries, 5000);
 
             // Act
-            RetryTag actual = parser.Parse(tag);
+            var actual = parser.Parse(tag);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -48,20 +57,25 @@ namespace UnitTests.SpecFlow.Parsers
         [InlineData("RETRY(5,100)", 5, 100)]
         [InlineData("rEtRy(5,100)", 5, 100)]
         [InlineData("retry(765,87)", 765, 87)]
-        public void Parse_MaxRetriesAndDelayBetweenRetriesMs_ReturnsCorrectResult(string tag, int maxRetries,
+        public void Parse_MaxRetriesAndDelayBetweenRetriesMs_ReturnsCorrectResult(
+            string tag,
+            int maxRetries,
             int delayBetweenRetriesMs)
         {
             // Arrange
-            RetryTagParser parser = getParser();
-            RetryTag expected = new RetryTag(maxRetries, delayBetweenRetriesMs);
+            var parser = getParser();
+            var expected = new RetryTag(maxRetries, delayBetweenRetriesMs);
 
             // Act
-            RetryTag actual = parser.Parse(tag);
+            var actual = parser.Parse(tag);
 
             // Assert
             Assert.Equal(expected, actual);
         }
 
-        private RetryTagParser getParser() => new RetryTagParser();
+        private RetryTagParser getParser()
+        {
+            return new(new RetrySettings());
+        }
     }
 }

--- a/test/UnitTests/SpecFlow/Steps/ScenarioOutlines/RetryScenarioOutlineSteps.cs
+++ b/test/UnitTests/SpecFlow/Steps/ScenarioOutlines/RetryScenarioOutlineSteps.cs
@@ -9,6 +9,7 @@ namespace UnitTests.SpecFlow.Steps.ScenarioOutlines
     {
         // testId => numCalls
         private static readonly ConcurrentDictionary<int, int> numCalls = new ConcurrentDictionary<int, int>();
+        private static readonly ConcurrentDictionary<int, int> numGlobalCalls = new ConcurrentDictionary<int, int>();
 
         [When(@"I increment the retry count for test (\d+)")]
         public void WhenIIncrementTheRetryCountForTest(int n)
@@ -20,6 +21,19 @@ namespace UnitTests.SpecFlow.Steps.ScenarioOutlines
         public void ThenTheRetryCountForTestShouldBe(int n, int expected)
         {
             Assert.True(numCalls.TryGetValue(n, out int actual), "Scenario example never ran");
+            Assert.Equal(expected, actual);
+        }
+
+        [When(@"I increment the global outline retry count for test (.+)")]
+        public void WhenIIncrementTheGlobalOutlineRetryCountForTestN(int n)
+        {
+            numGlobalCalls.AddOrUpdate(n, 1, (_, v) => v + 1);
+        }
+
+        [Then(@"the global outline retry could for test (\d+) should be (\d+)")]
+        public void ThenTheGlobalOutlineRetryCouldForTestNShouldBe3(int n, int expected)
+        {
+            Assert.True(numGlobalCalls.TryGetValue(n, out int actual), "Scenario example never ran");
             Assert.Equal(expected, actual);
         }
     }

--- a/test/UnitTests/SpecFlow/Steps/Scenarios/RetrySteps.cs
+++ b/test/UnitTests/SpecFlow/Steps/Scenarios/RetrySteps.cs
@@ -7,6 +7,7 @@ namespace UnitTests.SpecFlow.Steps.Scenarios
     public class RetrySteps
     {
         private static int retryCount = 0;
+        private static int retryGlobalCount = 0;
 
         [When(@"I increment the retry count")]
         public void WhenIIncrementTheRetryCount()
@@ -18,6 +19,18 @@ namespace UnitTests.SpecFlow.Steps.Scenarios
         public void ThenTheResultShouldBe(int expected)
         {
             Assert.Equal(expected, retryCount);
+        }
+
+        [When(@"I increment the global retry count")]
+        public void WhenIIncrementTheGlobalRetryCount()
+        {
+            retryGlobalCount++;
+        }
+
+        [Then(@"the global result should be (\d+)")]
+        public void ThenTheGlobalResultShouldBe(int expected)
+        {
+            Assert.Equal(expected, retryGlobalCount);
         }
     }
 }

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -32,18 +32,4 @@
     <ProjectReference Include="..\..\src\xRetry\xRetry.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="SpecFlowPlugin\Features\Retry.feature">
-      <Generator>SpecFlowSingleFileGenerator</Generator>
-      <LastGenOutput>Retry.feature.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <SpecFlowFeatureFiles Update="SpecFlow\Features\RetryScenarios.feature">
-      <Generator>SpecFlowSingleFileGenerator</Generator>
-      <LastGenOutput>RetryScenarios.feature.cs</LastGenOutput>
-    </SpecFlowFeatureFiles>
-  </ItemGroup>
-
 </Project>

--- a/test/UnitTests/retrySettings.json
+++ b/test/UnitTests/retrySettings.json
@@ -1,0 +1,6 @@
+{
+  "isVerbose": true,
+  "Global": true,
+  "MaxRetry": 3,
+  "DelayBetweenRetriesMs": 500
+} 


### PR DESCRIPTION
Hi, 

I add this optional configuration file : retrySettings.json
{
  "isVerbose": true,
  "Global": true,
  "MaxRetry": 3,
  "DelayBetweenRetriesMs": 500
} 

And some feature file to validate all changes.

The goal is to add retry trait to all specflow file