### PR TITLE
Decouple package versions

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,10 +1,10 @@
 XRETRY_VERSION			=1.9.0#
+XRETRY_VERSION_MAX		:= $(shell expr $(shell echo $(XRETRY_VERSION) | cut -d. -f1) + 1).0.0
 XRETRY_SPECFLOW_VERSION	=1.9.0#
 XRETRY_REQNOLL_VERSION	=1.1.0#
 XRETRY_V3_VERSION		=1.0.0-rc3#
+XRETRY_V3_VERSION_MAX	:= $(shell expr $(shell echo $(XRETRY_V3_VERSION) | cut -d. -f1) + 1).0.0
 XRETRY_V3_REQNROLL_VERSION	=0.1.0-alpha1#
-
-
 .PHONY: clean
 clean:
 	rm -r ../artefacts || true
@@ -121,7 +121,8 @@ nuget-create:
 
 	dotnet pack ../src/xRetry.SpecFlow \
 		-p:Version=$(XRETRY_SPECFLOW_VERSION) \
-		-p:xRetryVersion=$(XRETRY_VERSION) \
+		-p:xRetryVersionMin=$(XRETRY_VERSION) \
+		-p:xRetryVersionMax=$(XRETRY_VERSION_MAX) \
 		-p:NuspecFile=xRetry.SpecFlow.nuspec \
 		--no-build \
 		-c Release \
@@ -129,7 +130,8 @@ nuget-create:
 	
 	dotnet pack ../src/xRetry.Reqnroll \
 		-p:Version=$(XRETRY_REQNOLL_VERSION) \
-		-p:xRetryVersion=$(XRETRY_VERSION) \
+		-p:xRetryVersionMin=$(XRETRY_VERSION) \
+		-p:xRetryVersionMax=$(XRETRY_VERSION_MAX) \
 		-p:NuspecFile=xRetry.Reqnroll.nuspec \
 		--no-build \
 		-c Release \
@@ -144,7 +146,8 @@ nuget-create:
 	
 	dotnet pack ../src/xRetry.v3.Reqnroll \
 		-p:Version=$(XRETRY_V3_REQNROLL_VERSION) \
-		-p:xRetryV3Version=$(XRETRY_V3_VERSION) \
+		-p:xRetryV3VersionMin=$(XRETRY_V3_VERSION) \
+		-p:xRetryV3VersionMax=$(XRETRY_V3_VERSION_MAX) \
 		-p:NuspecFile=xRetry.v3.Reqnroll.nuspec \
 		--no-build \
 		-c Release \

--- a/src/xRetry.Reqnroll/xRetry.Reqnroll.csproj
+++ b/src/xRetry.Reqnroll/xRetry.Reqnroll.csproj
@@ -5,7 +5,7 @@
 	<AssemblyName>xRetry.ReqnrollPlugin</AssemblyName>
 
     <IsPackable>true</IsPackable>
-    <NuspecProperties>version=$(Version);xRetryVersion=$(xRetryVersion)</NuspecProperties>
+    <NuspecProperties>version=$(Version);xRetryVersionMin=$(xRetryVersionMin);xRetryVersionMax=$(xRetryVersionMax)</NuspecProperties>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/xRetry.Reqnroll/xRetry.Reqnroll.nuspec
+++ b/src/xRetry.Reqnroll/xRetry.Reqnroll.nuspec
@@ -15,7 +15,7 @@
 
     <dependencies>
       <dependency id="Reqnroll.xUnit" version="[2.0.0,4.0.0)" />
-      <dependency id="xRetry" version="[$xRetryVersion$]" />
+      <dependency id="xRetry" version="[$xRetryVersionMin$,$xRetryVersionMax$)" />
     </dependencies>
   </metadata>
 

--- a/src/xRetry.SpecFlow/xRetry.SpecFlow.csproj
+++ b/src/xRetry.SpecFlow/xRetry.SpecFlow.csproj
@@ -5,7 +5,7 @@
 	<AssemblyName>xRetry.SpecFlowPlugin</AssemblyName>
 
     <IsPackable>true</IsPackable>
-    <NuspecProperties>version=$(Version);xRetryVersion=$(xRetryVersion)</NuspecProperties>
+    <NuspecProperties>version=$(Version);xRetryVersionMin=$(xRetryVersionMin);xRetryVersionMax=$(xRetryVersionMax)</NuspecProperties>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/xRetry.SpecFlow/xRetry.SpecFlow.nuspec
+++ b/src/xRetry.SpecFlow/xRetry.SpecFlow.nuspec
@@ -15,7 +15,7 @@
 
     <dependencies>
       <dependency id="SpecFlow.xUnit" version="[3.9.50,3.10.0)" />
-      <dependency id="xRetry" version="[$xRetryVersion$]" />
+      <dependency id="xRetry" version="[$xRetryVersionMin$,$xRetryVersionMax$)" />
     </dependencies>
   </metadata>
 

--- a/src/xRetry.v3.Reqnroll/xRetry.v3.Reqnroll.csproj
+++ b/src/xRetry.v3.Reqnroll/xRetry.v3.Reqnroll.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>xRetry.v3.Reqnroll.Plugin</AssemblyName>
 
         <IsPackable>true</IsPackable>
-        <NuspecProperties>version=$(Version);xRetryV3Version=$(xRetryV3Version)</NuspecProperties>
+        <NuspecProperties>version=$(Version);xRetryV3VersionMin=$(xRetryV3VersionMin);xRetryV3VersionMax=$(xRetryV3VersionMax)</NuspecProperties>
         <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/xRetry.v3.Reqnroll/xRetry.v3.Reqnroll.nuspec
+++ b/src/xRetry.v3.Reqnroll/xRetry.v3.Reqnroll.nuspec
@@ -18,7 +18,7 @@
         <dependencies>
             <dependency id="Reqnroll.xunit.v3" version="[3.0.0,4.0.0)"/>
             <dependency id="xunit.v3.extensibility.core" version="[3.0.0,4.0.0)"/>
-            <dependency id="xRetry.v3" version="[$xRetryV3Version$]"/>
+            <dependency id="xRetry.v3" version="[$xRetryV3VersionMin$,$xRetryV3VersionMax$)"/>
         </dependencies>
     </metadata>
 


### PR DESCRIPTION
Changes Specflow & Reqnroll plugins to not depend on a specific version of xRetry/xRetry.v3. Instead they take the current version as the minimum & set the maximum as the next major version.

This will allow for the Specflow/Reqnroll plugins to use newer versions of xRetry/xRetry.v3, without needing a new release release of the Specflow/Reqnroll plugin.

Closes #297