### PR TITLE
Bump xunit.v3.extensibility.core and xunit.runner.visualstudio to 4.0.0

### DIFF
--- a/src/xRetry.v3.Reqnroll/xRetry.v3.Reqnroll.nuspec
+++ b/src/xRetry.v3.Reqnroll/xRetry.v3.Reqnroll.nuspec
@@ -17,7 +17,7 @@
 
         <dependencies>
             <dependency id="Reqnroll.xunit.v3" version="[3.0.0,4.0.0)"/>
-            <dependency id="xunit.v3.extensibility.core" version="[3.0.0,4.0.0)"/>
+            <dependency id="xunit.v3.extensibility.core" version="[4.0.0,5.0.0)"/>
             <dependency id="xRetry.v3" version="[$xRetryV3VersionMin$,$xRetryV3VersionMax$)"/>
         </dependencies>
     </metadata>

--- a/src/xRetry.v3/RetryTestCase.cs
+++ b/src/xRetry.v3/RetryTestCase.cs
@@ -50,7 +50,10 @@ namespace xRetry.v3
             IMessageBus messageBus,
             object?[] constructorArguments,
             ExceptionAggregator aggregator,
-            CancellationTokenSource cancellationTokenSource)
+            CancellationTokenSource cancellationTokenSource,
+            ParallelMode parallelMode,
+            ExecutionScheduler scheduler,
+            FixtureMappingManager methodFixtureMappings)
         {
             return await RetryTestCaseRunner.Instance.Run(
                 this,
@@ -61,7 +64,10 @@ namespace xRetry.v3
                 TestCaseDisplayName,
                 SkipReason,
                 explicitOption,
-                constructorArguments);
+                constructorArguments,
+                parallelMode,
+                scheduler,
+                methodFixtureMappings);
         }
 
         protected override void Serialize(IXunitSerializationInfo data)

--- a/src/xRetry.v3/RetryTestCaseRunner.cs
+++ b/src/xRetry.v3/RetryTestCaseRunner.cs
@@ -32,6 +32,9 @@ namespace xRetry.v3
         /// <param name="skipReason">The skip reason, if the test is to be skipped.</param>
         /// <param name="explicitOption">A flag to indicate how explicit tests should be treated.</param>
         /// <param name="constructorArguments">The arguments to be passed to the test class constructor.</param>
+        /// <param name="parallelMode">The parallel mode for the test case.</param>
+        /// <param name="scheduler">The scheduler used for task/test scheduling.</param>
+        /// <param name="methodFixtureMappings">The fixtures attached to the test method.</param>
         /// <returns>
         /// Run summary information about the test that was run.
         /// The .Time property includes any retry attempts.
@@ -50,7 +53,10 @@ namespace xRetry.v3
             string displayName,
             string? skipReason,
             ExplicitOption explicitOption,
-            object?[] constructorArguments)
+            object?[] constructorArguments,
+            ParallelMode parallelMode,
+            ExecutionScheduler scheduler,
+            FixtureMappingManager methodFixtureMappings)
         {
             Guard.ArgumentNotNull(testCase);
             Guard.ArgumentNotNull(displayName);
@@ -59,13 +65,16 @@ namespace xRetry.v3
             await using var ctxt = new XunitTestCaseRunnerContext(
                 testCase,
                 tests,
+                explicitOption,
                 messageBus,
                 aggregator,
-                cancellationTokenSource,
                 displayName,
                 skipReason,
-                explicitOption,
-                constructorArguments);
+                cancellationTokenSource,
+                parallelMode,
+                scheduler,
+                constructorArguments,
+                methodFixtureMappings);
             await ctxt.InitializeAsync();
 
             return await Run(ctxt);
@@ -104,7 +113,10 @@ namespace xRetry.v3
                     ctxt.ExplicitOption,
                     ctxt.Aggregator.Clone(),
                     ctxt.CancellationTokenSource,
-                    ctxt.BeforeAfterTestAttributes);
+                    ctxt.ParallelMode,
+                    ctxt.Scheduler,
+                    ctxt.BeforeAfterTestAttributes,
+                    ctxt.CaseFixtureMappings);
 
                 // If we succeeded, skipped, or we've reached the max retries return the result
                 if (summary.Failed == 0 || i == retryableTestCase.MaxRetries)

--- a/src/xRetry.v3/RetryTheoryAttribute.cs
+++ b/src/xRetry.v3/RetryTheoryAttribute.cs
@@ -12,6 +12,7 @@ namespace xRetry.v3
     public class RetryTheoryAttribute : RetryFactAttribute, ITheoryAttribute
     {
         public bool DisableDiscoveryEnumeration { get; set; }
+        public bool IncludeTestCaseIndex { get; set; }
         public bool SkipTestWithoutData { get; set; }
 
         /// <inheritdoc/>

--- a/src/xRetry.v3/RetryTheoryDiscoverer.cs
+++ b/src/xRetry.v3/RetryTheoryDiscoverer.cs
@@ -16,10 +16,11 @@ namespace xRetry.v3
             IXunitTestMethod testMethod,
             ITheoryAttribute theoryAttribute,
             ITheoryDataRow dataRow,
-            object?[] testMethodArguments)
+            object?[] testMethodArguments,
+            string? index)
         {
             var details = TestIntrospectionHelper.GetTestCaseDetailsForTheoryDataRow(
-                discoveryOptions, testMethod, theoryAttribute, dataRow, testMethodArguments);
+                discoveryOptions, testMethod, theoryAttribute, dataRow, testMethodArguments, index);
 
             IXunitTestCase testCase;
 

--- a/src/xRetry.v3/RetryTheoryDiscoveryAtRuntimeCase.cs
+++ b/src/xRetry.v3/RetryTheoryDiscoveryAtRuntimeCase.cs
@@ -55,7 +55,10 @@ namespace xRetry.v3
             IMessageBus messageBus,
             object?[] constructorArguments,
             ExceptionAggregator aggregator,
-            CancellationTokenSource cancellationTokenSource)
+            CancellationTokenSource cancellationTokenSource,
+            ParallelMode parallelMode,
+            ExecutionScheduler scheduler,
+            FixtureMappingManager methodFixtureMappings)
         {
             return await RetryTestCaseRunner.Instance.Run(
                 this,
@@ -66,7 +69,10 @@ namespace xRetry.v3
                 TestCaseDisplayName,
                 SkipReason,
                 explicitOption,
-                constructorArguments);
+                constructorArguments,
+                parallelMode,
+                scheduler,
+                methodFixtureMappings);
         }
 
         protected override void Serialize(IXunitSerializationInfo data)

--- a/src/xRetry.v3/xRetry.v3.csproj
+++ b/src/xRetry.v3/xRetry.v3.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/xRetry.v3/xRetry.v3.nuspec
+++ b/src/xRetry.v3/xRetry.v3.nuspec
@@ -15,12 +15,12 @@
 
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="xunit.v3.extensibility.core" version="[3.0.0,4.0.0)" />
+        <dependency id="xunit.v3.extensibility.core" version="[4.0.0,5.0.0)" />
       </group>
 
       <group targetFramework=".NETFramework4.7.2">
-        <dependency id="xunit.v3.extensibility.core" version="[3.0.0,4.0.0)" />
-      </group>      
+        <dependency id="xunit.v3.extensibility.core" version="[4.0.0,5.0.0)" />
+      </group>
     </dependencies>
   </metadata>
 

--- a/test/UnitTests.Reqnroll/UnitTests.Reqnroll.csproj
+++ b/test/UnitTests.Reqnroll/UnitTests.Reqnroll.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Reqnroll.xUnit" Version="3.3.2" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/UnitTests.SingleThreaded.v3/UnitTests.SingleThreaded.v3.csproj
+++ b/test/UnitTests.SingleThreaded.v3/UnitTests.SingleThreaded.v3.csproj
@@ -18,8 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <!-- xunit.v3 (MTP v2) fails to build on net48 with CS8336 on CI; mtp-off avoids it -->
+    <PackageReference Include="xunit.v3" Version="4.0.0" Condition="'$(TargetFramework)' != 'net48'" />
+    <PackageReference Include="xunit.v3.mtp-off" Version="4.0.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/UnitTests.SingleThreaded/UnitTests.SingleThreaded.csproj
+++ b/test/UnitTests.SingleThreaded/UnitTests.SingleThreaded.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/UnitTests.SpecFlow/UnitTests.SpecFlow.csproj
+++ b/test/UnitTests.SpecFlow/UnitTests.SpecFlow.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="SpecFlow.xUnit" Version="3.9.74" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/UnitTests.v3.Reqnroll/UnitTests.v3.Reqnroll.csproj
+++ b/test/UnitTests.v3.Reqnroll/UnitTests.v3.Reqnroll.csproj
@@ -26,9 +26,10 @@
         <PackageReference Include="FluentAssertions" Version="7.2.2"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
         <PackageReference Include="Reqnroll.xunit.v3" Version="3.3.2"/>
-        <PackageReference Include="xunit.v3" Version="3.2.2"/>
-        <PackageReference Include="xunit.v3.core" Version="3.2.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <!-- xunit.v3 (MTP v2) fails to build on net48 with CS8336 on CI; mtp-off avoids it -->
+        <PackageReference Include="xunit.v3" Version="4.0.0" Condition="'$(TargetFramework)' != 'net48'"/>
+        <PackageReference Include="xunit.v3.mtp-off" Version="4.0.0" Condition="'$(TargetFramework)' == 'net48'"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/UnitTests.v3/UnitTests.v3.csproj
+++ b/test/UnitTests.v3/UnitTests.v3.csproj
@@ -25,8 +25,10 @@
     -->
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <!-- xunit.v3 (MTP v2) fails to build on net48 with CS8336 on CI; mtp-off avoids it -->
+    <PackageReference Include="xunit.v3" Version="4.0.0" Condition="'$(TargetFramework)' != 'net48'" />
+    <PackageReference Include="xunit.v3.mtp-off" Version="4.0.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Adds support for `xunit.v3` / `xunit.v3.extensibility.core` **4.0.0**. Not just a version bump - 4.0.0 breaks the extensibility API `xRetry.v3` implements, so the dependency floor moves from `3.0.0` to `4.0.0` (3.x is no longer supported).

**`net472` workaround:**

`xunit.v3` v4.x dropped the MTP v1 support and switched to the MTP v2 by default. To mitigate this and avoid conditional references, the `.mtp-off` package was used.